### PR TITLE
✨ feat: 도메인 설계 (StudySession, Report) 및 JPA 설정 추가

### DIFF
--- a/src/main/java/com/poco/poco_backend/PocoBackendApplication.java
+++ b/src/main/java/com/poco/poco_backend/PocoBackendApplication.java
@@ -2,8 +2,10 @@ package com.poco.poco_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PocoBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/poco/poco_backend/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/poco/poco_backend/common/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.poco.poco_backend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/poco/poco_backend/common/enums/PeriodType.java
+++ b/src/main/java/com/poco/poco_backend/common/enums/PeriodType.java
@@ -1,0 +1,5 @@
+package com.poco.poco_backend.common.enums;
+
+public enum PeriodType {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
@@ -1,11 +1,11 @@
 package com.poco.poco_backend.domain.member.entity;
 
+import com.poco.poco_backend.common.entity.BaseTimeEntity;
 import com.poco.poco_backend.domain.report.entity.Report;
 import com.poco.poco_backend.domain.studySession.entity.StudySession;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "member")
-public class Member {
+public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -23,12 +23,6 @@ public class Member {
 
     @Column(name = "nickname")
     private String nickname;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "email")
     private String email;

--- a/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "member")
-public class MemberEntity {
+public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")

--- a/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/poco/poco_backend/domain/member/entity/Member.java
@@ -1,9 +1,13 @@
 package com.poco.poco_backend.domain.member.entity;
 
+import com.poco.poco_backend.domain.report.entity.Report;
+import com.poco.poco_backend.domain.studySession.entity.StudySession;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,5 +32,11 @@ public class Member {
 
     @Column(name = "email")
     private String email;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudySession> studySessions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Report> reports = new ArrayList<>();
 
 }

--- a/src/main/java/com/poco/poco_backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/controller/ReportController.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.report.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReportController {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/converter/ReportConverter.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/converter/ReportConverter.java
@@ -1,0 +1,8 @@
+package com.poco.poco_backend.domain.report.converter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReportConverter {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/dto/request/ReportRequestDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/dto/request/ReportRequestDTO.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.report.dto.request;
+
+public class ReportRequestDTO {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/dto/response/ReportResponseDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/dto/response/ReportResponseDTO.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.report.dto.response;
+
+public class ReportResponseDTO {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
@@ -1,7 +1,32 @@
 package com.poco.poco_backend.domain.report.entity;
 
-import jakarta.persistence.Entity;
+import com.poco.poco_backend.common.enums.PeriodType;
+import com.poco.poco_backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PeriodType periodType;
+
+    private LocalDate baseDate;
+    private Double avgFocusScore;
+    private LocalDateTime focusPeakTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReportSession> reportSessions = new ArrayList<>();
 }

--- a/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.report.entity;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Report {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/entity/Report.java
@@ -1,5 +1,6 @@
 package com.poco.poco_backend.domain.report.entity;
 
+import com.poco.poco_backend.common.entity.BaseTimeEntity;
 import com.poco.poco_backend.common.enums.PeriodType;
 import com.poco.poco_backend.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -10,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-public class Report {
+public class Report extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/poco/poco_backend/domain/report/entity/ReportSession.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/entity/ReportSession.java
@@ -1,0 +1,25 @@
+package com.poco.poco_backend.domain.report.entity;
+
+import com.poco.poco_backend.domain.studySession.entity.StudySession;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportSession {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private StudySession studySession;
+
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.report.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/service/command/ReportCommandService.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/service/command/ReportCommandService.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.report.service.command;
+
+public interface ReportCommandService {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/service/command/ReportCommandServiceImpl.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/service/command/ReportCommandServiceImpl.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.report.service.command;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportCommandServiceImpl {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/service/query/ReportQueryService.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/service/query/ReportQueryService.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.report.service.query;
+
+public interface ReportQueryService {
+}

--- a/src/main/java/com/poco/poco_backend/domain/report/service/query/ReportQueryServiceImpl.java
+++ b/src/main/java/com/poco/poco_backend/domain/report/service/query/ReportQueryServiceImpl.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.report.service.query;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportQueryServiceImpl {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/controller/StudySessionController.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/controller/StudySessionController.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.studySession.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StudySessionController {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/converter/StudySessionConverter.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/converter/StudySessionConverter.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.studySession.converter;
+
+public class StudySessionConverter {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/dto/request/StudySessionRequestDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/dto/request/StudySessionRequestDTO.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.studySession.dto.request;
+
+public class StudySessionRequestDTO {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/dto/response/StudySessionResponseDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/dto/response/StudySessionResponseDTO.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.studySession.dto.response;
+
+public class StudySessionResponseDTO {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.studySession.entity;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class StudySession {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
@@ -1,7 +1,34 @@
 package com.poco.poco_backend.domain.studySession.entity;
 
-import jakarta.persistence.Entity;
+import com.poco.poco_backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudySession {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private Long focusSeconds;
+    private Long distractionSeconds;
+    private Long breakSeconds;
+    private Long maxFocusDurationSeconds;
+
+    private LocalDateTime focusPeakTime;
+
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/repostitory/StudySessionRepository.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/repostitory/StudySessionRepository.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.studySession.repostitory;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudySessionRepository {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandService.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandService.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.studySession.service.command;
+
+public interface StudySessionCommandService {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandServiceImpl.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandServiceImpl.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.studySession.service.command;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StudySessionCommandServiceImpl implements StudySessionCommandService {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/query/StudySessionQueryService.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/query/StudySessionQueryService.java
@@ -1,0 +1,4 @@
+package com.poco.poco_backend.domain.studySession.service.query;
+
+public interface StudySessionQueryService {
+}

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/query/StudySessionQueryServiceImpl.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/query/StudySessionQueryServiceImpl.java
@@ -1,0 +1,7 @@
+package com.poco.poco_backend.domain.studySession.service.query;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StudySessionQueryServiceImpl implements StudySessionQueryService {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,16 @@ spring:
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+        jdbc:
+          batch_size: 1000
+          batch_versioned_data: true
+        order_inserts: true
+        order_updates: true


### PR DESCRIPTION
# ☝️Issue Number

- #1 

##  📌 개요

- Report 및 StudySession 도메인 설계 및 엔티티 구현
- 공통 시간 필드(createdAt, updatedAt)를 관리하기 위한 BaseTimeEntity 도입
- JPA 관련 설정(application.yml) 추가

## 🔁 변경 사항
- Report, StudySession 도메인 패키지 구조 설계 6e8acff4b3665046d60f56f0bc75eca556a3f18b cf648b849a5b8c5f84279e8fbef618e678ac1b8e
- Report, StudySession 엔티티 생성 94cf889d7d0ae337d3ff3496926bc4d594887e71
  - PeriodType Enum 추가
  - 연관관계 설정
- Member 엔티티명 수정 (MemberEntity → Member) ea0457bfa145e9909673a08ac899c02d1b055eb2
- BaseTimeEntity 생성 및 적용 4816f0d71e31f3455efb15e29d4f984db97033fe
  - createdAt, updatedAt 필드 포함
  - Report, Member에 적용
- application.yml에 JPA 설정 추가 fe1928b5b0e58f17d7796c9b99f8810d0d54f54b

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점