### PR TITLE
✨feat: 학습 세션 저장 (POST) API 구현

### DIFF
--- a/src/main/java/com/poco/poco_backend/domain/studySession/controller/StudySessionController.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/controller/StudySessionController.java
@@ -1,7 +1,39 @@
 package com.poco.poco_backend.domain.studySession.controller;
 
+import com.poco.poco_backend.domain.studySession.dto.request.StudySessionRequestDTO;
+import com.poco.poco_backend.domain.studySession.dto.response.StudySessionResponseDTO;
+import com.poco.poco_backend.domain.studySession.service.command.StudySessionCommandService;
+import com.poco.poco_backend.global.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/study-sessions")
+@Tag(name = "StudySession", description = "학습 세션 관련 API by 박현빈")
 public class StudySessionController {
+
+    private final StudySessionCommandService studySessionCommandService;
+
+    @Operation(
+            summary = "학습 세션 저장",
+            description = """
+                    사용자의 한 세션 동안의 집중/딴짓/휴식 기록을 저장합니다.\n
+                    프론트에서 타이머/딴짓/휴식의 시작/종료 시각을 타임스탬프 로그로 보내주면\n
+                    백엔드에서 집중 통계를 계산하여 저장하고 반환합니다.
+                    """
+    )
+    @PostMapping
+    public CustomResponse<StudySessionResponseDTO.CreateStudySessionResponseDTO> createSession(
+            @RequestBody StudySessionRequestDTO.CreateStudySessionRequestDTO request
+            // TODO: @AuthenticationPrincipal 추가
+    ) {
+        return CustomResponse.onSuccess(studySessionCommandService.createSession(request));
+    }
+
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/converter/StudySessionConverter.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/converter/StudySessionConverter.java
@@ -1,4 +1,38 @@
 package com.poco.poco_backend.domain.studySession.converter;
 
+import com.poco.poco_backend.domain.studySession.dto.request.StudySessionRequestDTO;
+import com.poco.poco_backend.domain.studySession.dto.response.StudySessionResponseDTO;
+import com.poco.poco_backend.domain.studySession.entity.StudySession;
+
 public class StudySessionConverter {
+
+    public static StudySession toStudySession(StudySessionRequestDTO.CreateStudySessionRequestDTO dto,
+                                       StudySessionRequestDTO.StudySessionCalculations calculations) {
+        return StudySession.builder()
+                .title(dto.title())
+                .startedAt(dto.startedAt())
+                .endedAt(dto.endedAt())
+                .sessionSeconds(calculations.sessionSeconds())
+                .focusSeconds(calculations.focusSeconds())
+                .distractionSeconds(calculations.distractionSeconds())
+                .breakSeconds(calculations.breakSeconds())
+                .longestFocusSeconds(calculations.longestFocusSeconds())
+                .focusScore(dto.focusScore())
+                .build();
+    }
+
+    public static StudySessionResponseDTO.CreateStudySessionResponseDTO toStudySessionResponseDTO(StudySession studySession) {
+        return StudySessionResponseDTO.CreateStudySessionResponseDTO.builder()
+                .sessionId(studySession.getId())
+                .title(studySession.getTitle())
+                .startedAt(studySession.getStartedAt())
+                .endedAt(studySession.getEndedAt())
+                .sessionSeconds(studySession.getSessionSeconds())
+                .focusSeconds(studySession.getFocusSeconds())
+                .distractionSeconds(studySession.getDistractionSeconds())
+                .breakSeconds(studySession.getBreakSeconds())
+                .longestFocusSeconds(studySession.getLongestFocusSeconds())
+                .focusScore(studySession.getFocusScore())
+                .build();
+    }
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/dto/request/StudySessionRequestDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/dto/request/StudySessionRequestDTO.java
@@ -1,4 +1,41 @@
 package com.poco.poco_backend.domain.studySession.dto.request;
 
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class StudySessionRequestDTO {
+
+    @Builder
+    public record CreateStudySessionRequestDTO(
+            String title,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            List<DistractionLog> distractionLogs,
+            List<BreakLog> breakLogs,
+            Double focusScore
+    ) {
+        public record DistractionLog(
+                LocalDateTime start,
+                LocalDateTime end
+        ) {
+        }
+
+        public record BreakLog(
+                LocalDateTime start,
+                LocalDateTime end
+        ) {
+        }
+    }
+
+    @Builder
+    public record StudySessionCalculations(
+            long sessionSeconds,
+            long focusSeconds,
+            long distractionSeconds,
+            long breakSeconds,
+            long longestFocusSeconds
+    ) {
+    }
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/dto/response/StudySessionResponseDTO.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/dto/response/StudySessionResponseDTO.java
@@ -1,4 +1,24 @@
 package com.poco.poco_backend.domain.studySession.dto.response;
 
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
 public class StudySessionResponseDTO {
+
+    @Builder
+    public record CreateStudySessionResponseDTO(
+            Long sessionId,
+            String title,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            Long sessionSeconds,
+            Long focusSeconds,
+            Long distractionSeconds,
+            Long breakSeconds,
+            Long longestFocusSeconds,
+            Double focusScore
+    ) {
+    }
+
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/entity/StudySession.java
@@ -2,14 +2,14 @@ package com.poco.poco_backend.domain.studySession.entity;
 
 import com.poco.poco_backend.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudySession {
 
@@ -18,15 +18,16 @@ public class StudySession {
 
     private String title;
 
+    private Long sessionSeconds;
     private Long focusSeconds;
     private Long distractionSeconds;
     private Long breakSeconds;
-    private Long maxFocusDurationSeconds;
-
-    private LocalDateTime focusPeakTime;
+    private Long longestFocusSeconds;
 
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;
+
+    private Double focusScore;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/poco/poco_backend/domain/studySession/repostitory/StudySessionRepository.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/repostitory/StudySessionRepository.java
@@ -1,7 +1,9 @@
 package com.poco.poco_backend.domain.studySession.repostitory;
 
+import com.poco.poco_backend.domain.studySession.entity.StudySession;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StudySessionRepository {
+public interface StudySessionRepository extends JpaRepository<StudySession, Long> {
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandService.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandService.java
@@ -1,4 +1,10 @@
 package com.poco.poco_backend.domain.studySession.service.command;
 
+import com.poco.poco_backend.domain.studySession.dto.request.StudySessionRequestDTO;
+import com.poco.poco_backend.domain.studySession.dto.response.StudySessionResponseDTO;
+
 public interface StudySessionCommandService {
+
+    StudySessionResponseDTO.CreateStudySessionResponseDTO createSession(StudySessionRequestDTO.CreateStudySessionRequestDTO createDTO);
+
 }

--- a/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandServiceImpl.java
+++ b/src/main/java/com/poco/poco_backend/domain/studySession/service/command/StudySessionCommandServiceImpl.java
@@ -1,7 +1,102 @@
 package com.poco.poco_backend.domain.studySession.service.command;
 
+import com.poco.poco_backend.domain.studySession.converter.StudySessionConverter;
+import com.poco.poco_backend.domain.studySession.dto.request.StudySessionRequestDTO;
+import com.poco.poco_backend.domain.studySession.dto.response.StudySessionResponseDTO;
+import com.poco.poco_backend.domain.studySession.entity.StudySession;
+import com.poco.poco_backend.domain.studySession.repostitory.StudySessionRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class StudySessionCommandServiceImpl implements StudySessionCommandService {
+
+    private final StudySessionRepository studySessionRepository;
+
+    @Override
+    public StudySessionResponseDTO.CreateStudySessionResponseDTO createSession(StudySessionRequestDTO.CreateStudySessionRequestDTO createDTO) {
+
+        // 총 세션 시간
+        long sessionSeconds = Duration.between(createDTO.startedAt(), createDTO.endedAt()).toSeconds();
+
+        // 총 딴짓 시간
+        long distractionSeconds = createDTO.distractionLogs().stream()
+                .mapToLong(log -> Duration.between(log.start(), log.end()).toSeconds())
+                .sum();
+
+        // 총 쉬는 시간
+        long breakSeconds = createDTO.breakLogs().stream()
+                .mapToLong(log -> Duration.between(log.start(), log.end()).toSeconds())
+                .sum();
+
+        // 총 집중 시간
+        long focusSeconds = sessionSeconds - distractionSeconds - breakSeconds;
+
+        // 최장 집중 지속 시간
+        long longestFocusSeconds = calculateLongestFocusSeconds(createDTO);
+
+        // 계산 DTO 생성
+        StudySessionRequestDTO.StudySessionCalculations calculations
+                = StudySessionRequestDTO.StudySessionCalculations.builder()
+                .sessionSeconds(sessionSeconds)
+                .focusSeconds(focusSeconds)
+                .distractionSeconds(distractionSeconds)
+                .breakSeconds(breakSeconds)
+                .longestFocusSeconds(longestFocusSeconds)
+                .build();
+
+        // 엔티티 생성 및 저장
+        StudySession session = StudySessionConverter.toStudySession(createDTO, calculations);
+        studySessionRepository.save(session);
+
+        return StudySessionConverter.toStudySessionResponseDTO(session);
+
+
+    }
+
+    // 최장 집중 지속 시간 계산 함수
+    private long calculateLongestFocusSeconds(StudySessionRequestDTO.CreateStudySessionRequestDTO dto) {
+        LocalDateTime startedAt = dto.startedAt();
+        LocalDateTime endedAt = dto.endedAt();
+        List<StudySessionRequestDTO.CreateStudySessionRequestDTO.DistractionLog> distractions = dto.distractionLogs();
+        List<StudySessionRequestDTO.CreateStudySessionRequestDTO.BreakLog> breaks = dto.breakLogs();
+
+        record TimeRange(LocalDateTime start, LocalDateTime end) {}
+
+        // 집중이 아닌 구간 (딴짓 시간 + 쉬는 시간)
+        List<TimeRange> nonFocused = new ArrayList<>();
+        distractions.forEach(log -> nonFocused.add(new TimeRange(log.start(), log.end())));
+        breaks.forEach(log -> nonFocused.add(new TimeRange(log.start(), log.end())));
+
+        // 시간 순 정렬
+        nonFocused.sort(Comparator.comparing(TimeRange::start));
+
+        // 집중 구간 추출 (전체 - nonFocused)
+        List<TimeRange> focused = new ArrayList<>();
+        LocalDateTime current = startedAt; // current로 기준점 설
+
+        for (TimeRange nonFocusedTime : nonFocused) {
+            if (current.isBefore(nonFocusedTime.start())) {
+                focused.add(new TimeRange(current, nonFocusedTime.start()));
+            }
+            current = nonFocusedTime.end();
+        }
+
+        if (current.isBefore(endedAt)) {
+            focused.add(new TimeRange(current, endedAt));
+        }
+
+        // 최장 집중 시간 반환
+        return focused.stream()
+                .mapToLong(range -> Duration.between(range.start(), range.end()).toSeconds())
+                .max()
+                .orElse(0L);
+    }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #7 

##  📌 개요

- 사용자의 한 학습 세션에 대한 집중/딴짓/휴식 시간 기록을 저장하는 API 구현
- 프론트에서 전달한 세션 제목, 시작/종료 시간, 딴짓·휴식 로그, 집중 점수를 받아 DB에 저장

## 🔁 변경 사항
- StudySessionController
  - `POST /api/v1/study-sessions` 추가
  - `CreateStudySessionRequestDTO` 기반으로 세션 생성 요청 처리

- StudySessionCommandService
  - `createStudySession()` 메서드 구현
  - 전달받은 시작/종료 시간과 로그들을 바탕으로 세션 시간 계산
  - `StudySession` 엔티티로 변환 후 저장

- StudySessionCalculations
  - 세션 전체 시간, 집중 시간, 딴짓 시간, 쉬는 시간, 최장 집중 시간 계산

- Swagger 설명 추가
  - 날짜 예시는 모두 `"2025-00-00T00:00:00"` 형식으로 통일

## 📸 스크린샷
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/a16e2478-e412-44b5-a2b3-cd1a31d5e95a" />
</br>
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/52241270-fbbe-46fa-a4d3-306176ddf9d6" />


## 👀 기타 더 이야기해볼 점
- 아직 Member 도메인 및 인증/인가 부분이 구현되지 않아 조회 부분은 추후 구현하도록 하겠습니다.
- 집중 피크 시간은 프론트 @Kwondongkyun과 회의 후 제거했습니다.