### PR TITLE
🐛 fix: 회원 삭제 로직 버그 수정(최종)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,11 +3,11 @@ name: Deploy to AWS EC2 using Docker
 
 # event
 #on:
-  #pr이 승인되었을 때 자동으로 배포되게 설정
-  #push:
-    #branches:
-      #- main
-  #workflow_dispatch:
+#  pr이 승인되었을 때 자동으로 배포되게 설정
+#  push:
+#    branches:
+#      - main
+#  workflow_dispatch:
 
 env:
   DOCKER_IMAGE_NAME: hanmin129/min

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,12 +2,12 @@
 name: Deploy to AWS EC2 using Docker
 
 # event
-on:
+#on:
   #pr이 승인되었을 때 자동으로 배포되게 설정
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  #push:
+    #branches:
+      #- main
+  #workflow_dispatch:
 
 env:
   DOCKER_IMAGE_NAME: hanmin129/min

--- a/src/main/java/com/poco/poco_backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/poco/poco_backend/domain/member/service/MemberService.java
@@ -14,9 +14,7 @@ import com.poco.poco_backend.domain.studySession.entity.StudySession;
 import com.poco.poco_backend.domain.studySession.repostitory.StudySessionRepository;
 import com.poco.poco_backend.global.exception.CustomException;
 import com.poco.poco_backend.global.security.jwt.JwtUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,7 +78,7 @@ public class MemberService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
-        List<StudySession> studySession = studySessionRepository.findByMember(member);
+        /*List<StudySession> studySession = studySessionRepository.findByMember(member);
 
         studySession.forEach(reportSessionRepository::deleteReportStudySessionByStudySession);
 
@@ -96,18 +94,20 @@ public class MemberService {
         log.info("[ Delete Member ] 회원 토큰 삭제 완료");
 
         int goalDeleted = memberGoalRepository.deleteMemberGoalByMember(member);
-        log.info("[ Delete Member ] Goal 과의 매핑 테이블 내의 레코드 {}건 삭제 완료", goalDeleted);
+        log.info("[ Delete Member ] Goal 과의 매핑 테이블 내의 레코드 {}건 삭제 완료", goalDeleted);*/
 
 
-        int memberDeleted = memberRepository.deleteMemberByEmail(email);
+       /* int memberDeleted = memberRepository.deleteMemberByEmail(email);*/
+
+        memberRepository.delete(member);
         log.info("[ Delete Member ] 회원 삭제 완료");
 
-        if (memberDeleted == 0)
+        /*if (memberDeleted == 0)
             log.warn("[ Delete Member ] 삭제할 회원이 존재하지 않습니다.");
-       /* else if (tokenDeleted == 0)
-            log.warn("[ Delete Member ] 삭제할 토큰이 존재하지 않습니다.");*/
+        else if (tokenDeleted == 0)
+            log.warn("[ Delete Member ] 삭제할 토큰이 존재하지 않습니다.");
         else
-            log.info("[ Delete Member ] 회원 탈퇴가 완료되었습니다.");
+            log.info("[ Delete Member ] 회원 탈퇴가 완료되었습니다.");*/
 
     }
 


### PR DESCRIPTION
# ☝️Issue Number

- #61 

##  📌 개요

- 회원 삭제 로직 리팩터링(최종)

## 🔁 변경 사항
모든 repository의 delete를 호출하여 매핑 테이블에 관련된 레코드부터 전부 수동으로 삭제하는 로직에서,
jpa가 자동으로 연관 레코드를 삭제하게 하는 방식으로 변경했습니다.
## 📸 스크린샷
## 👀 기타 더 이야기해볼 점
오류가 있는 채로 두기엔 뭔가 아쉬워서 수정했습니다.
~rds를 종료해서 테스트는 못 해봤지만 아마 이렇게 수정하면 잘 작동하지 않을까 싶습니다.~
~jpa공부 후 수정 예정...(삭제 처리 안 됨)~
삭제 처리 되는 것 확인
